### PR TITLE
New feature: test-output-verbosity switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .precomp
+*.iml
 .idea

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name": "Test::Output",
   "description": "Test the output to STDOUT and STDERR your program generates",
-  "version": "1.001003",
+  "version": "1.001004",
   "perl": "6.d",
   "authors": [
     "Zoffix Znet",

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Test::Output - Test the output to STDOUT and STDERR your program generates
 
 # TABLE OF CONTENTS
+
 - [NAME](#name)
 - [SYNOPSIS](#synopsis)
 - [DESCRIPTION](#description)
@@ -237,6 +238,31 @@ Same as [`output-from`](#output-from), except captures STDERR only.
 
 ----
 
+### `test-output-verbosity`
+
+![][sub-signature]
+```raku
+    sub test-output-verbosity (Bool :$on, Bool :$off) returns Str;
+```
+
+![][sub-usage-example]
+```raku
+    # turn verbosity on
+    test-output-verbosity(:on);
+    
+    my $output = output-from { do-something-interactive() };
+    # test output will now displayed during the test
+    
+    # turn verbosity off
+    test-output-verbosity(:off);
+```
+
+Display the code's output while the test code is executed. This can be
+very useful for author tests that require you to enter input based on
+the output.
+
+----
+
 # REPOSITORY
 
 Fork this module on GitHub:
@@ -258,4 +284,5 @@ The Artistic License 2.0. See the `LICENSE` file included in this
 distribution for complete details.
 
 [sub-signature]: _chromatin/sub-signature.png
+
 [sub-usage-example]: _chromatin/sub-usage-example.png

--- a/t/01-capture.t
+++ b/t/01-capture.t
@@ -23,4 +23,25 @@ is output-from( &test-code ), "42{$nl}warning!{$nl}After warning{$nl}",
 is stdout-from( &test-code ), "42{$nl}After warning{$nl}", 'stdout-from works';
 is stderr-from( &test-code ), "warning!{$nl}", 'stderr-from works';
 
+
+test-output-verbosity(:on);
+output-is   &test-code, "42{$nl}warning!{$nl}warning!{$nl}After warning{$nl}", 'verbosity testing output-is';
+
+output-like &test-code, /42.+warning '!' "\n" warning.+After/, 'verbosity testing output-like';
+
+stdout-is   &test-code, "42{$nl}warning!{$nl}After warning{$nl}";
+
+stdout-like &test-code, /42 "\n" warning '!'/;
+
+stderr-is   &test-code, "warning!{$nl}";
+
+stderr-like &test-code, /^ "warning!{$nl}" $/;
+
+is output-from( &test-code ), "42{$nl}warning!{$nl}warning!{$nl}After warning{$nl}",
+        'verbosity output-from works';
+
+is stdout-from( &test-code ), "42{$nl}warning!{$nl}After warning{$nl}", 'stdout-from works';
+
+is stderr-from( &test-code ), "warning!{$nl}", 'stderr-from works';
+
 done-testing;


### PR DESCRIPTION
Some author testing may require interaction with the distribution's code on the command line (getting input from the user, for example). This becomes difficult with Test::Output because output is suppressed.

This PR allows the tester to echo output to the screen during the test so the tester can interact with the program by setting a `$verbosity` flag in the `Test::Output` module.

The flag is activated with: `test-output-verbosity(:on)` and deactivated with `test-output-verbosity(:off)`.